### PR TITLE
Added support for package repackaging

### DIFF
--- a/src/BaGet.Core/IUrlGenerator.cs
+++ b/src/BaGet.Core/IUrlGenerator.cs
@@ -101,5 +101,13 @@ namespace BaGet.Core
         /// <param name="id">The package's ID</param>
         /// <param name="version">The package's version</param>
         string GetPackageIconDownloadUrl(string id, NuGetVersion version);
+
+        /// <summary>
+        /// Get the package repackage url with a replacement token for the new version {newVersion}
+        /// </summary>
+        /// <param name="id">The package ID</param>
+        /// <param name="version">The package version</param>
+        /// <param name="newVersion">The package new version</param>
+        string GetPackageRepackageUrl(string id, NuGetVersion version, NuGetVersion newVersion);
     }
 }

--- a/src/BaGet.Web/BaGetEndpointBuilder.cs
+++ b/src/BaGet.Web/BaGetEndpointBuilder.cs
@@ -46,6 +46,13 @@ namespace BaGet
                 pattern: "api/v2/package/{id}/{version}",
                 defaults: new { controller = "PackagePublish", action = "Relist" },
                 constraints: new { httpMethod = new HttpMethodRouteConstraint("POST") });
+
+            // This is an unofficial API to repackage a package as a new version
+            endpoints.MapControllerRoute(
+                name: Routes.RepackageRouteName,
+                pattern: "api/v2/package/{id}/{version}/repackage/{newVersion}",
+                defaults: new { controller = "PackagePublish", action = "Repackage" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("POST") });
         }
 
         public void MapSymbolRoutes(IEndpointRouteBuilder endpoints)

--- a/src/BaGet.Web/BaGetUrlGenerator.cs
+++ b/src/BaGet.Web/BaGetUrlGenerator.cs
@@ -161,5 +161,22 @@ namespace BaGet.Web
                 "/",
                 relativePath);
         }
+
+        public string GetPackageRepackageUrl(string id, NuGetVersion version, NuGetVersion newVersion)
+        {
+            id = id.ToLowerInvariant();
+            var versionString = version.ToNormalizedString().ToLowerInvariant();
+            var newVersionString = newVersion.ToNormalizedString().ToLowerInvariant();
+
+            return _linkGenerator.GetUriByRouteValues(
+                _httpContextAccessor.HttpContext,
+                Routes.RepackageRouteName,
+                values: new
+                {
+                    Id = id,
+                    Version = versionString,
+                    NewVersion = newVersionString
+                });
+        }
     }
 }

--- a/src/BaGet.Web/Pages/Package.cshtml
+++ b/src/BaGet.Web/Pages/Package.cshtml
@@ -239,6 +239,11 @@ else
                         <i class="ms-Icon ms-Icon--CloudDownload"></i>
                         <a href="@Model.PackageDownloadUrl">Download package</a>
                     </li>
+
+                    <li>
+                        <i class="ms-Icon ms-Icon--Package"></i>
+                        <a href="#" data-toggle="modal" data-target="#repackage">Repackage</a>
+                    </li>
                 </ul>
             </div>
 
@@ -268,6 +273,44 @@ else
             }
         </aside>
     </div>
+
+    <!-- Modal -->
+    <form id="repackage-form">
+        <div class="modal fade" id="repackage" tabindex="-1" role="dialog" aria-labelledby="repackageLabel" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="repackageLabel">Repackage Nuget Package</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                    <div id="repackage-alert" class="alert alert-danger alert-dismissible fade hide" role="alert">
+                       <div id="repackage-error"></div>
+                    </div>
+                    <div class="form-group">
+                        <label>Package name</label>
+                        <input type="text" readonly class="form-control" value="@Model.Package.Id" />
+                    </div>
+                    <div class="form-group">
+                        <label>Package version</label>
+                        <input type="text" readonly class="form-control" value="@Model.Package.NormalizedVersionString" />
+                    </div>
+
+                    <div class="form-group">
+                        <label for="repackage-version">New Version</label>
+                        <input type="text" class="form-control" id="repackage-version" value="@Model.Package.NormalizedVersionString">
+                    </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" id="repackage-button" class="btn btn-primary">Repackage</button>
+              </div>
+            </div>
+          </div>
+        </div>
+    </form>
 }
 
 @if (Model.Found)
@@ -321,6 +364,35 @@ else
             }
         ];
     </script>
+
+    @section Scripts {
+        <script>
+            const repackageButton = $("#repackage-button");
+
+            repackageButton.click(() => {
+                const repackageForm = $("#repackage-form");
+                const repackageVersion = $("#repackage-version");
+
+                const postUrl = "@Model.RepackageUrl".replace("0.0.0", repackageVersion.val());
+
+                $.ajax({
+                    type: "POST",
+                    url: postUrl,
+                    success: () => {
+                        location.href = "@Url.Page("package", new{ id= Model.Package.Id, version = "0.0.0"})".replace("0.0.0", repackageVersion.val());
+                    },
+                    error: response => {
+                        $("#repackage-error").text(response.responseText);
+                        $("#repackage-alert").removeClass("fade").addClass("show")
+                    },
+                    headers:  {
+                        "X-NuGet-ApiKey": "@Model.ApiKey"
+                    }
+                });
+            });
+
+        </script>
+    }
 }
 
 @functions {

--- a/src/BaGet.Web/Pages/Package.cshtml.cs
+++ b/src/BaGet.Web/Pages/Package.cshtml.cs
@@ -8,6 +8,7 @@ using BaGet.Core;
 using Markdig;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
@@ -20,6 +21,7 @@ namespace BaGet.Web
         private readonly IPackageService _packages;
         private readonly IPackageContentService _content;
         private readonly ISearchService _search;
+        private readonly IOptionsSnapshot<BaGetOptions> _options;
         private readonly IUrlGenerator _url;
 
         static PackageModel()
@@ -33,11 +35,13 @@ namespace BaGet.Web
             IPackageService packages,
             IPackageContentService content,
             ISearchService search,
+            IOptionsSnapshot<BaGetOptions> options,
             IUrlGenerator url)
         {
             _packages = packages ?? throw new ArgumentNullException(nameof(packages));
             _content = content ?? throw new ArgumentNullException(nameof(content));
             _search = search ?? throw new ArgumentNullException(nameof(search));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
             _url = url ?? throw new ArgumentNullException(nameof(url));
         }
 
@@ -59,6 +63,8 @@ namespace BaGet.Web
         public string IconUrl { get; private set; }
         public string LicenseUrl { get; private set; }
         public string PackageDownloadUrl { get; private set; }
+        public string RepackageUrl { get; private set; }
+        public string ApiKey { get; private set; }
 
         public async Task OnGetAsync(string id, string version, CancellationToken cancellationToken)
         {
@@ -84,6 +90,8 @@ namespace BaGet.Web
                 return;
             }
 
+            ApiKey = _options.Value.ApiKey;
+
             var packageVersion = Package.Version;
 
             Found = true;
@@ -108,6 +116,7 @@ namespace BaGet.Web
                 : Package.IconUrlString;
             LicenseUrl = Package.LicenseUrlString;
             PackageDownloadUrl = _url.GetPackageDownloadUrl(Package.Id, packageVersion);
+            RepackageUrl = _url.GetPackageRepackageUrl(Package.Id, packageVersion, NuGetVersion.Parse("0.0.0"));
         }
 
         private IReadOnlyList<DependencyGroupModel> ToDependencyGroups(Package package)

--- a/src/BaGet.Web/Routes.cs
+++ b/src/BaGet.Web/Routes.cs
@@ -8,6 +8,7 @@ namespace BaGet.Web
         public const string DeleteRouteName = "delete";
         public const string RelistRouteName = "relist";
         public const string SearchRouteName = "search";
+        public const string RepackageRouteName = "repackage";
         public const string AutocompleteRouteName = "autocomplete";
         public const string DependentsRouteName = "dependents";
         public const string RegistrationIndexRouteName = "registration-index";

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -10,7 +10,7 @@
 
   "Storage": {
     "Type": "FileSystem",
-    "Path": ""
+    "Path": "D:\\baget-packages"
   },
 
   "Search": {

--- a/tests/BaGet.Web.Tests/Pages/PackageModelFacts.cs
+++ b/tests/BaGet.Web.Tests/Pages/PackageModelFacts.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGet.Core;
+using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Versioning;
 using Xunit;
@@ -17,6 +18,7 @@ namespace BaGet.Web.Tests
         private readonly Mock<IPackageService> _packages;
         private readonly Mock<ISearchService> _search;
         private readonly Mock<IUrlGenerator> _url;
+        private readonly Mock<IOptionsSnapshot<BaGetOptions>> _options;
         private readonly PackageModel _target;
 
         private readonly CancellationToken _cancellation = CancellationToken.None;
@@ -27,10 +29,12 @@ namespace BaGet.Web.Tests
             _packages = new Mock<IPackageService>();
             _search = new Mock<ISearchService>();
             _url = new Mock<IUrlGenerator>();
+            _options = new Mock<IOptionsSnapshot<BaGetOptions>>();
             _target = new PackageModel(
                 _packages.Object,
                 _content.Object,
                 _search.Object,
+                _options.Object,
                 _url.Object);
 
             _search


### PR DESCRIPTION
The following PR adds support on the UI and the API for package repacking, this means that starting from a version you can republish it as another version, this is useful for scenarios where you have a prerelease package and you want to turn it into a release package

The following is the url for repackaging

api/v2/package/{id}/{version}/repackage/{newVersion}
