### PR TITLE
Addressing concurrency exceptions when incrementing the download count.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ publish/
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
+ServiceDependencies/
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
 # checkin your Azure Web App publish settings, but sensitive information contained

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-
+    <LangVersion>8</LangVersion>
     <PackageTags>NuGet</PackageTags>
     <Description>The core libraries that power BaGet.</Description>
   </PropertyGroup>

--- a/src/BaGet.Core/Entities/IContext.cs
+++ b/src/BaGet.Core/Entities/IContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -5,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace BaGet.Core
 {
-    public interface IContext
+    public interface IContext : IDisposable
     {
         DatabaseFacade Database { get; }
 

--- a/src/BaGet.Core/Entities/NullContext.cs
+++ b/src/BaGet.Core/Entities/NullContext.cs
@@ -28,5 +28,10 @@ namespace BaGet.Core
         {
             throw new NotImplementedException();
         }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/BaGet.Core/Extensions/DependencyInjectionExtensions.Providers.cs
+++ b/src/BaGet.Core/Extensions/DependencyInjectionExtensions.Providers.cs
@@ -72,10 +72,10 @@ namespace BaGet.Core
             Action<IServiceProvider, DbContextOptionsBuilder> configureContext)
             where TContext : DbContext, IContext
         {
-            services.TryAddScoped<IContext>(provider => provider.GetRequiredService<TContext>());
+            services.TryAddTransient<IContext>(provider => provider.GetRequiredService<TContext>());
             services.TryAddTransient<IPackageDatabase>(provider => provider.GetRequiredService<PackageDatabase>());
 
-            services.AddDbContext<TContext>(configureContext);
+            services.AddDbContext<TContext>(configureContext, contextLifetime: ServiceLifetime.Transient);
 
             services.AddProvider<IContext>((provider, config) =>
             {

--- a/src/BaGet.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGet.Core/Extensions/DependencyInjectionExtensions.cs
@@ -144,7 +144,7 @@ namespace BaGet.Core
 
         private static void AddFallbackServices(this IServiceCollection services)
         {
-            services.TryAddScoped<IContext, NullContext>();
+            services.TryAddTransient<IContext, NullContext>();
 
             // BaGet's services have multiple implementations that live side-by-side.
             // The application will choose the implementation using one of two ways:

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -43,7 +43,8 @@ namespace BaGet
             // You can swap between implementations of subsystems like storage and search using BaGet's configuration.
             // Each subsystem's implementation has a provider that reads the configuration to determine if it should be
             // activated. BaGet will run through all its providers until it finds one that is active.
-            services.AddScoped(DependencyInjectionExtensions.GetServiceFromProviders<IContext>);
+            services.AddTransient(DependencyInjectionExtensions.GetServiceFromProviders<IContext>);
+            services.AddSingleton<Func<IContext>>(s => () => s.GetService<IContext>());
             services.AddTransient(DependencyInjectionExtensions.GetServiceFromProviders<IStorageService>);
             services.AddTransient(DependencyInjectionExtensions.GetServiceFromProviders<IPackageDatabase>);
             services.AddTransient(DependencyInjectionExtensions.GetServiceFromProviders<ISearchService>);

--- a/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
+++ b/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -60,6 +61,7 @@ namespace BaGet.Core.Tests.Metadata
                 PackageTypes = new List<PackageType> { new PackageType { Name = "test" } },
                 Dependencies = new List<PackageDependency> { },
                 Version = new NuGetVersion(version),
+                Published = DateTimeOffset.MinValue.UtcDateTime
             };
         }
     }

--- a/tests/BaGet.Core.Tests/Services/PackageDatabaseTests.cs
+++ b/tests/BaGet.Core.Tests/Services/PackageDatabaseTests.cs
@@ -197,7 +197,7 @@ namespace BaGet.Core.Tests.Services
             public FactsBase()
             {
                 _context = new Mock<IContext>();
-                _target = new PackageDatabase(_context.Object);
+                _target = new PackageDatabase(_context.Object, () => new Mock<IContext>().Object);
             }
         }
     }


### PR DESCRIPTION
### Summary

Automatic retry when incrementing the download count throws DbUpdateConcurrencyException.

### Problem

When a package is requested, BaGet will update the package record, incrementing the Downloads field by 1. This is done with EF Core, where the record is first retrieved from the database, modified in memory, and then saved with a call to SaveChangesAsync().

If the record in the database is modified in between retrieving the record and the call to SaveChangesAsync, then a DbUpdateConcurrencyException is raised, leading to a 500 status code and the following error message:

Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException: Database operation expected to affect 1 row(s) but actually affected 0 row(s). Data may have been modified or deleted since entities were loaded. See http://go.microsoft.com/fwlink/?LinkId=527962 for information on understanding and handling optimistic concurrency exceptions.

This can happen when there are two requests for the same package around the same time, which should be expected for parallel CI pipelines running dotnet restore or for popular packages.
Solution

I have fixed the issue for myself (I think) and have created this PR in case you would like to merge it, or to help anyone else with the issue.

The solution works by retrying the operation up to 5 attempts, and then throwing the error.

Something I needed to do (which you might not be happy with) is to change the DbContext registration from scoped to transient. This is so that I can create a new DbContext for each attempt rather than fix up a DbContext in an invalid state.

I also needed to fix up the tests, which were failing in my local environment (because of UTC+8).

Another idea might be to find a platform independent way to run the following SQL, without first having to retrieve the record and therefore risk the concurrency error in the first place.

UPDATE
    Packages
SET
    Downloads = Downloads + 1 
WHERE 
    Id = @id AND
    NormalizedVersionString = @normalizedVersionString 
